### PR TITLE
Update README.md with current installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,30 @@
 
 This is a guard for [nanoc](http://nanoc.ws/).
 
-## Installation
+## A note on Rubygems ownership
+
+The RubyGems gem name 'guard-nanoc' is currently taken by an old and now defunct [project](https://github.com/guard/guard-nanoc) - while the author and RubyGems.org are being contacted, you can use Git instead:
+
+### Installing with Git
 
 Add this line to your application's Gemfile:
 
-    gem 'guard-nanoc'
+    gem 'guard-nanoc', :github => 'nanoc/guard-nanoc'
 
-And then execute:
+Or, to fetch it manually: 
+
+    $ git clone git://github.com/nanoc/guard-nanoc.git 
+    $ cd guard-nanoc 
+    $ gem build guard-nanoc.gemspec 
+    $ gem install guard-nanoc-*.gem 
+
+then add this line to your application's Gemfile:
+
+    gem 'guard-nanoc', :path => '/path/to/local/gem/guard-nanoc-*'
+
+After setting up the gem either way, run:
 
     $ bundle
-
-Or install it yourself as:
-
-    $ gem install guard-nanoc
 
 ## Usage
 
@@ -25,3 +36,5 @@ Create a Guardfile using `guard init`:
 Execute guard:
 
     $ guard
+    
+N.B. Remember to run `bundle exec guard` if you're using Bundler


### PR DESCRIPTION
Replaced the installation instructions with the ones that work _as of now_, to save confusion for people that found the repo without knowledge of the RubyGems issue.
