### PR TITLE
Update deprecated code (since Guard 2.0)

### DIFF
--- a/lib/guard/nanoc.rb
+++ b/lib/guard/nanoc.rb
@@ -1,16 +1,16 @@
 # encoding: utf-8
 
 require 'guard'
-require 'guard/guard'
+require 'guard/plugin'
 
 require 'nanoc'
 require 'nanoc/cli'
 
 module Guard
 
-  class Nanoc < Guard
+  class Nanoc < Plugin
 
-    def initialize(watchers=[], options={})
+    def initialize(options={})
       @dir = options[:dir] || '.'
       super
     end


### PR DESCRIPTION
Recent versions of Guard emit a deprecation warning (see below) about requiring the deprecated 'guard/guard', inheriting from Guard instead of Plugin, and about the changed signature of #initialize. This patch addresses those issues.

See also: https://github.com/guard/guard/wiki/Upgrading-to-Guard-2.0#changes-in-guardguard

```
******** BIG DEPRECATION WARNING !! ********

Hi, Guard here.

You're including lib/guard/guard.rb ...

... which contains code deprecated over a year ago!


This file will likely be removed in the next version, so make sure you're
not requiring it anywhere to ensure safe gem upgrades.

If this message is annoying and you can't quickly fix the issue (see below),
you have 2 options:

  1) Simply set the env variable "GUARD_GEM_SILENCE_DEPRECATIONS" to "1" to
  skip this message

  2) Freeze the gem to a previous version (not recommended because upgrades
  are cool and you might forget to unfreeze later!).

  E.g. in your Gemfile:

    if Time.now > Time.new(2014,11,10)
      gem 'guard', '~> 2.8'
    else
      # Freeze until 2014-11-10 - in case we forget to change back ;)
      gem 'guard', '= 2.7.3'
    end

If you don't know which gem or plugin is requiring this file, here's a
backtrace:

/var/lib/gems/2.1.0/gems/guard-2.8.0/lib/guard/guard.rb:45:in `<module:Guard>'
     >> /var/lib/gems/2.1.0/gems/guard-2.8.0/lib/guard/guard.rb:3:in `<top (required)>'
     >> /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
     >> /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
     >> /var/lib/gems/2.1.0/gems/guard-nanoc-1.0.2/lib/guard/nanoc.rb:4:in `<top (required)>'"

Here's how to quickly upgrade/fix this (given you are a maintainer of the
offending plugin or you want to prepare a pull request yourself):

  https://github.com/guard/guard/wiki/Upgrading-to-Guard-2.0#changes-in-guardguard

Have fun!

******** END OF DEPRECATION MESSAGE ********
```
