### PR TITLE
Update for nanoc 4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'nanoc'
+gem 'nanoc', github: 'nanoc/nanoc'
 
 group :test do
   gem 'rake'

--- a/guard-nanoc.gemspec
+++ b/guard-nanoc.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'guard', '~> 2.8'
   s.add_dependency 'guard-compat', '~> 1.0'
-  s.add_dependency 'nanoc', '~> 3.6'
+  s.add_dependency 'nanoc', '~> 4.0.0b4'
 
   s.files         = Dir['[A-Z]*'] + Dir['lib/**/*'] + [ 'guard-nanoc.gemspec' ]
   s.require_paths = [ 'lib' ]

--- a/lib/guard/nanoc.rb
+++ b/lib/guard/nanoc.rb
@@ -35,13 +35,13 @@ module Guard
 
     def setup_nanoc_notifications
       @rep_times = {}
-      ::Nanoc::NotificationCenter.on(:compilation_started) do |rep|
+      ::Nanoc::Int::NotificationCenter.on(:compilation_started) do |rep|
         @rep_times[rep.raw_path] = Time.now
       end
-      ::Nanoc::NotificationCenter.on(:compilation_ended) do |rep|
+      ::Nanoc::Int::NotificationCenter.on(:compilation_ended) do |rep|
         @rep_times[rep.raw_path] = Time.now - @rep_times[rep.raw_path]
       end
-      ::Nanoc::NotificationCenter.on(:rep_written) do |rep, path, is_created, is_modified|
+      ::Nanoc::Int::NotificationCenter.on(:rep_written) do |rep, path, is_created, is_modified|
         action = (is_created ? :create : (is_modified ? :update : :identical))
         level  = (is_created ? :high   : (is_modified ? :high   : :low))
         duration = Time.now - @rep_times[rep.raw_path] if @rep_times[rep.raw_path]
@@ -60,15 +60,12 @@ module Guard
 
     def recompile
       Dir.chdir(@dir) do
-        site = ::Nanoc::Site.new('.')
+        site = ::Nanoc::Int::Site.new('.')
         site.compile
         self.prune(site)
       end
       self.notify_success
-    rescue ::Nanoc::Errors::GenericTrivial => e
-      self.notify_failure
-      $stderr.puts e.message
-    rescue RuntimeError => e
+    rescue => e
       self.notify_failure
       ::Nanoc::CLI::ErrorHandler.print_error(e)
     end

--- a/lib/guard/nanoc.rb
+++ b/lib/guard/nanoc.rb
@@ -60,7 +60,7 @@ module Guard
 
     def recompile
       Dir.chdir(@dir) do
-        site = ::Nanoc::Int::Site.new('.')
+        site = ::Nanoc::Int::SiteLoader.new.new_from_cwd
         site.compile
         self.prune(site)
       end

--- a/spec/lib/guard/nanoc_spec.rb
+++ b/spec/lib/guard/nanoc_spec.rb
@@ -3,9 +3,9 @@ require "guard/nanoc"
 
 
 RSpec.describe Guard::Nanoc do
-  let!(:site) { instance_double(Nanoc::Site) }
+  let!(:site) { instance_double(Nanoc::Int::Site) }
 
-  let(:site_class) { class_double(Nanoc::Site) }
+  let(:site_class) { class_double(Nanoc::Int::Site) }
 
   before do
     allow(Process).to receive(:fork) do |_args, &block|
@@ -20,7 +20,7 @@ RSpec.describe Guard::Nanoc do
     allow(Guard::Compat::UI).to receive(:error)
     allow(Guard::Compat::UI).to receive(:info)
 
-    stub_const("Nanoc::Site", site_class)
+    stub_const("Nanoc::Int::Site", site_class)
     allow(site_class).to receive(:new).and_return(site)
 
     allow(site).to receive(:compile)
@@ -43,7 +43,7 @@ RSpec.describe Guard::Nanoc do
 
     context "with errors" do
       before do
-        allow(site).to receive(:compile).and_raise(::Nanoc::Errors::GenericTrivial)
+        allow(site).to receive(:compile).and_raise(::Nanoc::Int::Errors::GenericTrivial)
       end
 
       it "outputs failure" do

--- a/spec/lib/guard/nanoc_spec.rb
+++ b/spec/lib/guard/nanoc_spec.rb
@@ -3,10 +3,6 @@ require "guard/nanoc"
 
 
 RSpec.describe Guard::Nanoc do
-  let!(:site) { instance_double(Nanoc::Int::Site) }
-
-  let(:site_class) { class_double(Nanoc::Int::Site) }
-
   before do
     allow(Process).to receive(:fork) do |_args, &block|
       @_fork_block = block
@@ -19,13 +15,6 @@ RSpec.describe Guard::Nanoc do
     allow(Guard::Compat::UI).to receive(:notify)
     allow(Guard::Compat::UI).to receive(:error)
     allow(Guard::Compat::UI).to receive(:info)
-
-    stub_const("Nanoc::Int::Site", site_class)
-    allow(site_class).to receive(:new).and_return(site)
-
-    allow(site).to receive(:compile)
-    allow(site).to receive(:config).and_return({})
-    allow($stderr).to receive(:puts)
   end
 
   describe "#start" do
@@ -43,7 +32,7 @@ RSpec.describe Guard::Nanoc do
 
     context "with errors" do
       before do
-        allow(site).to receive(:compile).and_raise(::Nanoc::Int::Errors::GenericTrivial)
+        File.write('nanoc.yaml', '[][]]}][]{}][')
       end
 
       it "outputs failure" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,35 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  # Swallow stdout/stderr
+  config.around(:each) do |example|
+    old_stdout = $stdout
+    old_stderr = $stderr
+
+    $stdout = StringIO.new
+    $stderr = StringIO.new
+
+    begin
+      example.run
+    ensure
+      $stdout = old_stdout
+      $stderr = old_stderr
+    end
+  end
+
+  # In temporary site
+  config.around(:each) do |example|
+    Dir.mktmpdir('nanoc-test') do |dir|
+      FileUtils.cd(dir) do
+        Nanoc::CLI.run(%w( create-site foo ))
+
+        FileUtils.cd('foo') do
+          example.run
+        end
+      end
+    end
+  end
+
   config.filter_run :focus
   config.run_all_when_everything_filtered = true
 


### PR DESCRIPTION
Since this change is incompatible with nanoc 3.x, this should probably become guard-nanoc 2.0.