### PR TITLE
Restore Nanoc 4.3.8 compatiblity

### DIFF
--- a/guard-nanoc.gemspec
+++ b/guard-nanoc.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'guard', '~> 2.8'
   s.add_dependency 'guard-compat', '~> 1.0'
-  s.add_dependency 'nanoc', '~> 4.0'
+  s.add_dependency 'nanoc', '>= 4.3.8', '< 5.0'
 
   s.files         = Dir['[A-Z]*'] + Dir['lib/**/*'] + [ 'guard-nanoc.gemspec' ]
   s.require_paths = [ 'lib' ]

--- a/lib/guard/nanoc.rb
+++ b/lib/guard/nanoc.rb
@@ -62,21 +62,11 @@ module Guard
       Dir.chdir(@dir) do
         site = ::Nanoc::Int::SiteLoader.new.new_from_cwd
         site.compile
-        self.prune(site)
       end
       self.notify_success
     rescue => e
       self.notify_failure
       ::Nanoc::CLI::ErrorHandler.print_error(e)
-    end
-
-    def prune(site)
-      prune_config = site.config.fetch(:prune, {})
-      auto_prune_enabled = prune_config.fetch(:auto_prune, false)
-      if auto_prune_enabled
-        exclude = prune_config.fetch(:exclude, [])
-        ::Nanoc::Extra::Pruner.new(site, :exclude => exclude).run
-      end
     end
 
     def notify_success


### PR DESCRIPTION
The API of the `Pruner` has changed, which broke guard-nanoc. Since  pruning is now handled by the compiler, it can be safely removed from guard-nanoc.

Fixes #31.

CC @whitequark 