### PR TITLE
Ensure view options are also part of live cmd

### DIFF
--- a/lib/guard-nanoc.rb
+++ b/lib/guard-nanoc.rb
@@ -1,8 +1,1 @@
-require 'nanoc'
-require 'nanoc/cli'
-
-Nanoc::CLI.after_setup do
-  live_command_path =
-    File.join(File.dirname(__FILE__), 'nanoc', 'cli', 'commands', 'live.rb')
-  Nanoc::CLI.add_command(Nanoc::CLI.load_command_at(live_command_path))
-end
+require 'guard/nanoc'

--- a/lib/guard/nanoc.rb
+++ b/lib/guard/nanoc.rb
@@ -7,6 +7,13 @@ require 'nanoc/cli'
 
 module Guard
   class Nanoc < Plugin
+    def self.live_cmd
+      @_live_cmd ||= begin
+        path = File.join(File.dirname(__FILE__), '..', 'nanoc', 'cli', 'commands', 'live.rb')
+        ::Nanoc::CLI.load_command_at(path)
+      end
+    end
+
     def initialize(options={})
       @dir = options[:dir] || '.'
       super
@@ -69,4 +76,8 @@ module Guard
       Compat::UI.error 'Compilation failed!'
     end
   end
+end
+
+::Nanoc::CLI.after_setup do
+  ::Nanoc::CLI.add_command(Guard::Nanoc.live_cmd)
 end

--- a/lib/nanoc/cli/commands/live.rb
+++ b/lib/nanoc/cli/commands/live.rb
@@ -6,9 +6,10 @@ in the background (like `guard start` would). See the documentation of those
 two commands for details. The options are forwarded to `nanoc view` only.
 EOS
 
-required :H, :handler, 'specify the handler to use (webrick/mongrel/...)'
-required :o, :host,    'specify the host to listen on (default: 0.0.0.0)'
-required :p, :port,    'specify the port to listen on (default: 3000)'
+required :H, :handler,       'specify the handler to use (webrick/mongrel/...)'
+required :o, :host,          'specify the host to listen on (default: 0.0.0.0)'
+required :p, :port,          'specify the port to listen on (default: 3000)'
+flag     :L, :'live-reload', 'reload on changes'
 
 module Nanoc::CLI::Commands
   class Live < ::Nanoc::CLI::CommandRunner

--- a/spec/lib/guard/nanoc_spec.rb
+++ b/spec/lib/guard/nanoc_spec.rb
@@ -45,4 +45,13 @@ RSpec.describe Guard::Nanoc do
       end
     end
   end
+
+  describe 'command' do
+    it 'has an option set that is a superset of the view command’s options' do
+      view_cmd = Nanoc::CLI.root_command.command_named('view')
+      live_cmd = Guard::Nanoc.live_cmd
+
+      expect(live_cmd.option_definitions).not_to eq(view_cmd.option_definitions)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #38.

This adds the missing options to the `live` command, and also ensures that this bug won’t happen again.