### PR TITLE
Fix the link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-The contents of this repository have moved [into the nanoc/nanoc repository](https://github.com/nanoc/nanoc/tree/master/guard-nanoc).
+The contents of this repository have moved [into the nanoc/nanoc repository](https://github.com/nanoc/nanoc/tree/main/guard-nanoc).


### PR DESCRIPTION
It moved since the branch name changed from `master` to `main`.

Close #40 